### PR TITLE
Ignore UTF-8 decode errors when decoding socket data

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -161,7 +161,7 @@ while True:
             data = s.recv(4096)
             if len(data) < 1:
                 break
-            js += data.decode('utf8')
+            js += data.decode('utf8', 'ignore')
     except IOError as e:
         if e.errno != errno.EINTR:
             raise


### PR DESCRIPTION
If URL or headers received from socket contain unparsable characters
uwsgitop will crash with "unable to get uWSGI statistics" message since
it does not catch UnicodeDecodeError.
