### PR TITLE
Add python 3 classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,9 @@ setup(
     install_requires = [
         'simplejson',
         'argparse',
+    ],
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
     ]
 )


### PR DESCRIPTION
uwsgitop seems to work fine with Python 3, after #10 .  Adding this allows PyPI and `caniusepython3` to mark uwsgitop as python3 compatible.  