### PR TITLE
Update setup.py, newly in uwsgitop==0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
     license='MIT',
     long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
     scripts=['uwsgitop'],
+    python_requires='<3',
     install_requires=[
         'argparse',
-        'python_version<3',
     ],
     classifiers=[
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
     scripts=['uwsgitop'],
     install_requires=[
-        'argparse;python_version<"3"',
+        'argparse',
+        'python_version<3',
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
In my server, the pip-7.1.0 and pip-8.1.1 also exist,  and when I install the uwsgitop.
```
>  /usr/local/bin/pip install -V
pip 7.1.0 from /usr/local/lib/python2.7/dist-packages (python 2.7)

> /usr/local/bin/pip install -U uwsgitop
You are using pip version 7.1.0, however version 18.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting uwsgitop
  Downloading http://pypi.doubanio.com/packages/8a/7a/9501084f6d2739b8a7d35ef5fb9cb539edb6e0a0d559366598b82bb7a96e/uwsgitop-0.11.tar.gz
    Complete output from command python setup.py egg_info:
    error in uwsgitop setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected version spec in argparse;python_version<"3" at ;python_version<"3"
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-DMc9_S/uwsgitop
```

There are many servers that keep the old pip version, I believe that people with old pip will also encounter this problem, hope you can accept my pull request.