### PR TITLE
show full datetime in LastSpwn output

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -259,7 +259,7 @@ def main():
             for worker in dd['workers']:
                 sigs = 0
                 wtx = human_size(worker['tx'])
-                wlastspawn = "-"
+                wlastspawn = "--:--:--"
 
                 wrunt = worker['running_time']/1000
                 if wrunt > 9999999:

--- a/uwsgitop
+++ b/uwsgitop
@@ -259,7 +259,7 @@ def main():
             for worker in dd['workers']:
                 sigs = 0
                 wtx = human_size(worker['tx'])
-                wlastspawn = "--:--:--"
+                wlastspawn = "-"
 
                 wrunt = worker['running_time']/1000
                 if wrunt > 9999999:
@@ -268,7 +268,7 @@ def main():
                     wrunt = str(wrunt)
 
                 if worker['last_spawn']:
-                    wlastspawn = time.strftime("%H:%M:%S", time.localtime(worker['last_spawn']))
+                    wlastspawn = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(worker['last_spawn']))
 
                 color = curses.color_pair(0)
                 if 'signals' in worker:


### PR DESCRIPTION
Currently `LastSpwn` only shows hour-min-sec for last spawn, even though the value exposed by uwsgi is a unix epoch timestamp. This change exposes it as an ISO8601 timestamp in the users local time, as is current practice.