### PR TITLE
"-n option" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,7 @@ nosetests.xml
 # PyCharm
 .idea
 
+# Virtual Environment
+.venv
+
 pylokit/tests/.~*

--- a/uwsgitop
+++ b/uwsgitop
@@ -76,6 +76,14 @@ def parse_args():
 
     return parser.parse_args()
 
+
+def capture_curses_content(screen):
+    rows, cols = screen.getmaxyx()
+    binary_lines = (screen.instr(i, 0) for i in range(rows))
+    text_lines = (bl.decode("utf-8", errors="ignore") for bl in binary_lines)
+    return "".join(tl for tl in text_lines if tl.strip())
+
+
 def main():
 
     need_reset = True

--- a/uwsgitop
+++ b/uwsgitop
@@ -71,6 +71,7 @@ def merge_worker_with_cores(workers, rps_per_worker, cores, rps_per_core):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--frequency', type=int, default=1, help='Refresh frequency in seconds')
+    parser.add_argument('-n', type=int, default=None, help='Number of cycles until uwsgitop quits')
     parser.add_argument('address', help='uWSGI stats socket or address')
 
     return parser.parse_args()

--- a/uwsgitop
+++ b/uwsgitop
@@ -14,6 +14,7 @@ import sys
 import traceback
 from collections import defaultdict
 import errno
+import itertools
 
 
 def human_size(n):

--- a/uwsgitop
+++ b/uwsgitop
@@ -156,8 +156,8 @@ def main():
     fast_screen = 0
 
     # number of cycles to display
-   max_cycle = args.n
-   cycle = itertools.count()
+    max_cycle = args.n
+    cycle = itertools.count()
 
     while True:
 

--- a/uwsgitop
+++ b/uwsgitop
@@ -155,7 +155,18 @@ def main():
     async_mode = 0
     fast_screen = 0
 
+    # number of cycles to display
+   max_cycle = args.n
+   cycle = itertools.count()
+
     while True:
+
+        # break out of loop if number of cycles reached
+        if max_cycle and max_cycle == next(cycle):
+            content = capture_curses_content(screen)
+            game_over()
+            print(content)
+            break
 
         if fast_screen == 1:
             screen.timeout(100)


### PR DESCRIPTION
I was looking for a way to capture the output of uwsgitop and came upon issue #54. 

This is a first try on this:
 - added an "-n" option to specify the number of cycles before uwsgitop quits
 - if the "-n" option is present, the content of the curses interface is captured, and after terminating the curses interface echoed to stdout

