### PR TITLE
Add option to configure address using environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,13 @@ You'll now need to call uwsgitop as::
 
     uwsgitop http://127.0.0.1:3031
 
+
+You can also use the `UWSGITOP_ADDRESS` environment variable to define a default socket or address and run uwsgitop without any arguments like this::
+
+    export UWSGITOP_ADDRESS="/tmp/stats.socket"
+    uwsgitop
+
+
 Installation
 ------------
 

--- a/uwsgitop
+++ b/uwsgitop
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import os
 try:
     import urllib2
 except ImportError:
@@ -69,9 +70,13 @@ def merge_worker_with_cores(workers, rps_per_worker, cores, rps_per_core):
     workers[:] = new_workers
 
 def parse_args():
+    default_address = os.environ.get("UWSGITOP_ADDRESS")
+    address_nargs = "?" if default_address else None
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--frequency', type=int, default=1, help='Refresh frequency in seconds')
-    parser.add_argument('address', help='uWSGI stats socket or address')
+    parser.add_argument('address', help='uWSGI stats socket or address', nargs=address_nargs,
+                        default=default_address)
 
     return parser.parse_args()
 


### PR DESCRIPTION
This implements the suggestion from #65.

A default address (or socket) is now read from the `UWSGITOP_ADDRESS` environment variable if it's available. If the environment variable is defined you can now call `uwsgitop` without any parameters.